### PR TITLE
allow env config (e.g GDAL_TIFF_OVR_BLOCKSIZE)

### DIFF
--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -1,5 +1,6 @@
 """Rio_cogeo.scripts.cli."""
 
+import os
 import click
 
 from rasterio.rio import options
@@ -84,9 +85,9 @@ def cogeo(
 
     config = dict(
         NUM_THREADS=threads,
-        BIGTIFF="IF_SAFER",
-        GDAL_TIFF_INTERNAL_MASK=True,
-        GDAL_TIFF_OVR_BLOCKSIZE=block_size,
+        BIGTIFF=os.environ.get("BIGTIFF", "IF_SAFER"),
+        GDAL_TIFF_INTERNAL_MASK=os.environ.get("GDAL_TIFF_INTERNAL_MASK", True),
+        GDAL_TIFF_OVR_BLOCKSIZE=os.environ.get("GDAL_TIFF_OVR_BLOCKSIZE", block_size),
     )
 
     cog_translate(

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -78,6 +78,7 @@ def cogeo(
         raise click.ClickException('Incompatible options "alpha" and "nodata"')
 
     output_profile = cog_profiles.get(cogeo_profile)
+    output_profile.update(dict(BIGTIFF=os.environ.get("BIGTIFF", "IF_SAFER")))
     if creation_options:
         output_profile.update(creation_options)
 
@@ -85,7 +86,6 @@ def cogeo(
 
     config = dict(
         NUM_THREADS=threads,
-        BIGTIFF=os.environ.get("BIGTIFF", "IF_SAFER"),
         GDAL_TIFF_INTERNAL_MASK=os.environ.get("GDAL_TIFF_INTERNAL_MASK", True),
         GDAL_TIFF_OVR_BLOCKSIZE=os.environ.get("GDAL_TIFF_OVR_BLOCKSIZE", block_size),
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,6 +31,22 @@ def test_cogeo_valid():
             assert src.overviews(1) == [2, 4, 8, 16, 32, 64]
 
 
+def test_cogeo_valid_external_mask(monkeypatch):
+    """Should work as expected."""
+    monkeypatch.setenv("GDAL_TIFF_INTERNAL_MASK", "FALSE")
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cogeo, [raster_path_rgba, "output.tif", "-b", "1,2,3", "--alpha", 4]
+        )
+
+        assert not result.exception
+        assert result.exit_code == 0
+        with rasterio.open("output.tif") as src:
+            assert "output.tif.msk" in src.files
+
+
 def test_cogeo_validbidx():
     """Should work as expected."""
     runner = CliRunner()


### PR DESCRIPTION
Allow users to pass configuration from Environment Variables.

By default we decided to force `GDAL_TIFF_INTERNAL_MASK` to **True** and the `GDAL_TIFF_OVR_BLOCKSIZE` to be the same size as the data block size but users should be able to overwrite that. 


cc @sgillies 