### PR TITLE
Fix typos in usage example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Examples
   $ rio cogeo mydataset.tif mydataset_ycbcr.tif -b 1,2,3
 
   # Create a COGEO without compression and wiht 1024x1024 block size
-  $ rio cogeo mydataset.tif mydataset_raw.tif -co BLOCKXSIZE=1024 -co BLOCKXSIZE=1024 --cog-profile raw
+  $ rio cogeo mydataset.tif mydataset_raw.tif --co BLOCKXSIZE=1024 --co BLOCKYSIZE=1024 --cog-profile raw
 
 Default COGEO profiles
 ======================

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ Examples
   # Create a COGEO with YCbCR profile and the first 3 bands of the data
   $ rio cogeo mydataset.tif mydataset_ycbcr.tif -b 1,2,3
 
-  # Create a COGEO without compression and wiht 1024x1024 block size
+  # Create a COGEO without compression and with 1024x1024 block size
   $ rio cogeo mydataset.tif mydataset_raw.tif --co BLOCKXSIZE=1024 --co BLOCKYSIZE=1024 --cog-profile raw
 
 Default COGEO profiles


### PR DESCRIPTION
Saw some typos in the second usage example which would result in errors if run. 

- Option should be `--co` instead of `-co`. 
- `BLOCKXSIZE` option is duplicated

Fixed typos in the comment as well