### PR TITLE
add more overview resampling method

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Next release
 ------------
 - write tags in output file (#31)
+- add bilinear, cubic spline, lanczos resampling modes for overviews
 
 1.0dev7 (2018-09-12)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -48,12 +48,12 @@ Usage
     --nodata INTEGER                Force mask creation from a given nodata value
     --alpha INTEGER                 Force mask creation from a given alpha band number
     --overview-level INTEGER        Overview level (default: 6)
+    --overview-resampling [nearest|bilinear|cubic|cubic_spline|lanczos|average|mode|gauss] Resampling algorithm.
     --threads INTEGER
     --co, --profile NAME=VALUE      Driver specific creation options.See the
                                     documentation for the selected output driver
                                     for more information.
     --help                          Show this message and exit.
-
 
 Examples
 ========

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 click
-rasterio~=1.0
+rasterio>=1.0.4

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -58,7 +58,9 @@ class CustomType:
 @click.option(
     "--overview-resampling",
     help="Resampling algorithm.",
-    type=click.Choice([it.name for it in Resampling if it.value in [0, 2, 5, 6, 7]]),
+    type=click.Choice(
+        [it.name for it in Resampling if it.value in [0, 1, 2, 3, 4, 5, 6, 7]]
+    ),
     default="nearest",
 )
 @click.option("--threads", type=int, default=8)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("README.rst") as f:
     readme = f.read()
 
 # Runtime requirements.
-inst_reqs = ["rasterio[s3]~=1.0"]
+inst_reqs = ["click", "rasterio[s3]>=1.0.4"]
 
 extra_reqs = {
     "test": ["pytest", "pytest-cov"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,7 +140,7 @@ def test_cogeo_validOvrOption():
                 "--overview-level",
                 2,
                 "--overview-resampling",
-                "cubic",
+                "bilinear",
             ],
         )
         assert not result.exception


### PR DESCRIPTION
this PR adds more resampling method for overviews. 

Status: Do not merge  because it depends on the next rasterio release (1.0.4) ref: https://github.com/mapbox/rasterio/pull/1458/files