### PR TITLE
write tags on final file

### DIFF
--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -88,9 +88,10 @@ def cog_translate(
                     overviews = [2 ** j for j in range(1, overview_level + 1)]
 
                     mem.build_overviews(overviews, Resampling[overview_resampling])
-                    mem.update_tags(
-                        ns="rio_overview",
-                        resampling=Resampling[overview_resampling].value,
-                    )
 
                     copy(mem, dst_path, copy_src_overviews=True, **dst_kwargs)
+
+    with rasterio.open(dst_path, "r+") as dst:
+        dst.update_tags(
+            ns="rio_overview", resampling=Resampling[overview_resampling].value
+        )

--- a/tests/test_cogeo.py
+++ b/tests/test_cogeo.py
@@ -29,6 +29,7 @@ def test_cog_translate_valid():
             assert src.photometric.value == "YCbCr"
             assert src.interleaving.value == "PIXEL"
             assert src.overviews(1) == [2, 4, 8, 16, 32, 64]
+            assert src.tags(ns="rio_overview") == {"resampling": "0"}
 
 
 def test_cog_translate_validRaw():


### PR DESCRIPTION
`rasterio.shutil.copy` doesn't pass tag so to make sure the output file has the good tags we need to write them after the `copy`