### PR TITLE
Calculate overview level automatically 

### DIFF
--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -53,8 +53,7 @@ def cog_translate(
 
     if overview_level is None:
         overview_level = get_overview_level(
-            src_path,
-            min(dst_kwargs["blockxsize"], dst_kwargs["blockysize"])
+            src_path, min(dst_kwargs["blockxsize"], dst_kwargs["blockysize"])
         )
 
     with rasterio.Env(**config):

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -11,7 +11,7 @@ from rasterio.io import MemoryFile
 from rasterio.enums import Resampling
 from rasterio.shutil import copy
 
-from rio_cogeo.utils import get_overview_level
+from rio_cogeo.utils import get_maximum_overview_level
 
 
 def cog_translate(
@@ -52,7 +52,7 @@ def cog_translate(
     config = config or {}
 
     if overview_level is None:
-        overview_level = get_overview_level(
+        overview_level = get_maximum_overview_level(
             src_path, min(dst_kwargs["blockxsize"], dst_kwargs["blockysize"])
         )
 

--- a/rio_cogeo/cogeo.py
+++ b/rio_cogeo/cogeo.py
@@ -11,6 +11,8 @@ from rasterio.io import MemoryFile
 from rasterio.enums import Resampling
 from rasterio.shutil import copy
 
+from rio_cogeo.utils import get_overview_level
+
 
 def cog_translate(
     src_path,
@@ -19,7 +21,7 @@ def cog_translate(
     indexes=None,
     nodata=None,
     alpha=None,
-    overview_level=6,
+    overview_level=None,
     overview_resampling="nearest",
     config=None,
 ):
@@ -48,6 +50,12 @@ def cog_translate(
 
     """
     config = config or {}
+
+    if overview_level is None:
+        overview_level = get_overview_level(
+            src_path,
+            min(dst_kwargs["blockxsize"], dst_kwargs["blockysize"])
+        )
 
     with rasterio.Env(**config):
         with rasterio.open(src_path) as src:

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -53,7 +53,9 @@ class CustomType:
     "--alpha", type=int, help="Force mask creation from a given alpha band number"
 )
 @click.option(
-    "--overview-level", type=int, help="Overview level (if not provided, appropriate overview level will be selected until the smallest overview is smaller than the internal block size)"
+    "--overview-level",
+    type=int,
+    help="Overview level (if not provided, appropriate overview level will be selected until the smallest overview is smaller than the internal block size)",
 )
 @click.option(
     "--overview-resampling",

--- a/rio_cogeo/scripts/cli.py
+++ b/rio_cogeo/scripts/cli.py
@@ -53,7 +53,7 @@ class CustomType:
     "--alpha", type=int, help="Force mask creation from a given alpha band number"
 )
 @click.option(
-    "--overview-level", type=int, default=6, help="Overview level (default: 6)"
+    "--overview-level", type=int, help="Overview level (if not provided, appropriate overview level will be selected until the smallest overview is smaller than the internal block size)"
 )
 @click.option(
     "--overview-resampling",

--- a/rio_cogeo/utils.py
+++ b/rio_cogeo/utils.py
@@ -1,0 +1,17 @@
+"""rio_cogeo.utils: Utility functions."""
+
+import rasterio
+
+
+def get_overview_level(src_path, minsize=512):
+    """Calculate the maximum overview level."""
+    with rasterio.open(src_path) as src:
+        width = src.width
+        height = src.height
+    nlevel = 0
+    overview = 1
+    while (min(width // overview, height // overview) > minsize):
+        overview *= 2
+        nlevel += 1
+
+    return nlevel

--- a/rio_cogeo/utils.py
+++ b/rio_cogeo/utils.py
@@ -3,14 +3,16 @@
 import rasterio
 
 
-def get_overview_level(src_path, minsize=512):
+def get_maximum_overview_level(src_path, minsize=512):
     """Calculate the maximum overview level."""
     with rasterio.open(src_path) as src:
         width = src.width
         height = src.height
+
     nlevel = 0
     overview = 1
-    while (min(width // overview, height // overview) > minsize):
+
+    while min(width // overview, height // overview) > minsize:
         overview *= 2
         nlevel += 1
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,7 @@ def test_cogeo_valid():
             assert src.compression.value == "JPEG"
             assert src.photometric.value == "YCbCr"
             assert src.interleaving.value == "PIXEL"
-            assert src.overviews(1) == [2, 4, 8, 16, 32, 64]
+            assert not src.overviews(1)
 
 
 def test_cogeo_valid_external_mask(monkeypatch):

--- a/tests/test_cogeo.py
+++ b/tests/test_cogeo.py
@@ -28,7 +28,7 @@ def test_cog_translate_valid():
             assert src.compression.value == "JPEG"
             assert src.photometric.value == "YCbCr"
             assert src.interleaving.value == "PIXEL"
-            assert src.overviews(1) == [2, 4, 8, 16, 32, 64]
+            assert not src.overviews(1)
             assert src.tags()["OVR_RESAMPLING_ALG"] == "NEAREST"
 
 
@@ -47,7 +47,7 @@ def test_cog_translate_validRaw():
             )  # Because blocksize is 512 and the file is 512, the output is not tiled
             assert not src.compression
             assert src.interleaving.value == "PIXEL"
-            assert src.overviews(1) == [2, 4, 8, 16, 32, 64]
+            assert not src.overviews(1)
 
 
 def test_cog_translate_validAlpha():
@@ -123,4 +123,4 @@ def test_cog_translate_validCustom():
             assert src.profile["blockysize"] == 256
             assert src.photometric.value == "YCbCr"
             assert src.interleaving.value == "PIXEL"
-            assert src.overviews(1) == [2, 4, 8, 16, 32, 64]
+            assert src.overviews(1) == [2]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,11 +2,11 @@
 
 import os
 
-from rio_cogeo.utils import get_overview_level
+from rio_cogeo.utils import get_maximum_overview_level
 
 raster_path_rgb = os.path.join(os.path.dirname(__file__), "fixtures", "image_rgb.tif")
 
 
 def test_overviewlevel_valid():
     """Should work as expected (return overview level)."""
-    assert get_overview_level(raster_path_rgb, 128) == 2
+    assert get_maximum_overview_level(raster_path_rgb, 128) == 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+"""tests rio_cogeo.cogeo."""
+
+import os
+
+from rio_cogeo.utils import get_overview_level
+
+raster_path_rgb = os.path.join(os.path.dirname(__file__), "fixtures", "image_rgb.tif")
+
+
+def test_overviewlevel_valid():
+    """Should work as expected (return overview level)."""
+    assert get_overview_level(raster_path_rgb, 128) == 2


### PR DESCRIPTION
This PR adds a `get_overview_level` utility function to calculate the maximum overview level based on the image `block size`. 